### PR TITLE
Adjusting message to be tighter

### DIFF
--- a/GW2-DonBot/Services/DiscordMessagingServices/MessageGenerationService.cs
+++ b/GW2-DonBot/Services/DiscordMessagingServices/MessageGenerationService.cs
@@ -31,6 +31,8 @@ namespace Services.DiscordMessagingServices
 
         private const int NameSizeLength = 21;
 
+        private const int PlayersListed = 10;
+
         public Embed GenerateFightSummary(BotSecretsDataModel secrets, EliteInsightDataModel data)
         {
             // Building the actual message to be sent
@@ -131,20 +133,17 @@ namespace Services.DiscordMessagingServices
             battleGroundColor = battleGround.Contains("Edge", StringComparison.OrdinalIgnoreCase) ? System.Drawing.Color.FromArgb(193, 105, 79) : battleGroundColor;
 
             // Embed content building
-            var friendlyOverview = "```Players  Damage     DPS     Downs   Deaths \n";
-            friendlyOverview      += $"-------  -------  -------  -------  -------\n";
+            var friendlyOverview = "```";
             friendlyOverview      += $"{friendlyCountStr}  {friendlyDamageStr}  {friendlyDPSStr}  {friendlyDownsStr}  {friendlyDeathsStr}```";
 
-            var enemyOverview = "```Players  Damage     DPS     Downs   Deaths \n";
-            enemyOverview      += $"-------  -------  -------  -------  -------\n";
+            var enemyOverview = "```";
             enemyOverview      += $"{enemyCountStr}  {enemyDamageStr}  {enemyDPSStr}  {enemyDownsStr}  {enemyDeathsStr}```";
 
             // Damage overview
-            var damageOverview = "``` #           Name          Damage     DPS  \n";
-            damageOverview      += $"-------------------------  -------  -------\n";
+            var damageOverview = "```";
 
             var maxDamage = -1.0f;
-            for (var index = 0; index < 5; index++)
+            for (var index = 0; index < PlayersListed; index++)
             {
                 if (index + 1 > sortedPlayerIndexByDamage?.Count)
                 {
@@ -165,16 +164,15 @@ namespace Services.DiscordMessagingServices
                     maxDamage = damageFloat;
                 }
 
-                damageOverview += $" {index + 1}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {damageFloat.FormatNumber(maxDamage).PadCenter(7)}  {(damageFloat / logLength).FormatNumber(maxDamage / logLength).PadCenter(7)}\n";
+                damageOverview += $"{(index + 1).ToString().PadLeft(2, '0')}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {damageFloat.FormatNumber(maxDamage).PadCenter(7)}  {(damageFloat / logLength).FormatNumber(maxDamage / logLength).PadCenter(7)}\n";
             }
 
             damageOverview += "```";
 
             // Cleanse overview
-            var cleanseOverview = $"``` #           Name              Cleanses    \n";
-            cleanseOverview       += $"-------------------------  ----------------\n";
+            var cleanseOverview = $"```";
 
-            for (var index = 0; index < 5; index++)
+            for (var index = 0; index < PlayersListed; index++)
             {
                 if (index + 1 > sortedPlayerIndexByCleanses?.Count)
                 {
@@ -190,16 +188,15 @@ namespace Services.DiscordMessagingServices
                 var name = data.Players?[cleanses.Key].Name;
                 var prof = data.Players?[cleanses.Key].Profession;
 
-                cleanseOverview += $" {index + 1}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {cleanses.Value.ToString(CultureInfo.InvariantCulture).PadCenter(16)}\n";
+                cleanseOverview += $"{(index + 1).ToString().PadLeft(2, '0')}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {cleanses.Value.ToString(CultureInfo.InvariantCulture).PadCenter(16)}\n";
             }
 
             cleanseOverview += "```";
 
             // Strip overview
-            var stripOverview = "``` #           Name               Strips     \n";
-            stripOverview       += "-------------------------  ----------------\n";
+            var stripOverview = "```";
 
-            for (var index = 0; index < 5; index++)
+            for (var index = 0; index < PlayersListed; index++)
             {
                 if (index + 1 > sortedPlayerIndexByStrips?.Count)
                 {
@@ -215,16 +212,15 @@ namespace Services.DiscordMessagingServices
                 var name = data.Players?[strips.Key].Name;
                 var prof = data.Players?[strips.Key].Profession;
 
-                stripOverview += $" {index + 1}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {strips.Value.ToString(CultureInfo.InvariantCulture).PadCenter(16)}\n";
+                stripOverview += $"{(index + 1).ToString().PadLeft(2, '0')}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {strips.Value.ToString(CultureInfo.InvariantCulture).PadCenter(16)}\n";
             }
 
             stripOverview += "```";
 
             // Stab overview
-            var stabOverview = "``` #           Name          Sub     Uptime  \n";
-            stabOverview       += "-------------------------  ---  -----------\n";
+            var stabOverview = "```";
 
-            for (var index = 0; index < 5; index++)
+            for (var index = 0; index < PlayersListed; index++)
             {
                 if (index + 1 > sortedPlayerIndexByStab?.Count)
                 {
@@ -241,7 +237,7 @@ namespace Services.DiscordMessagingServices
                 var name = data.Players?[stab.Key].Name;
                 var prof = data.Players?[stab.Key].Profession;
 
-                stabOverview += $" {index + 1}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {sub.ToString().PadCenter(3)}  {stab.Value.FormatPercentage().PadCenter(11)}\n";
+                stabOverview += $"{(index + 1).ToString().PadLeft(2, '0')}  {(name?.ClipAt(NameClipLength) + EliteInsightExtensions.GetClassAppend(prof)).PadRight(NameSizeLength)}  {sub.ToString().PadCenter(3)}  {stab.Value.FormatPercentage().PadCenter(11)}\n";
             }
 
             stabOverview += "```";
@@ -263,45 +259,47 @@ namespace Services.DiscordMessagingServices
 
             message.AddField(x =>
             {
-                x.Name = "Friends";
+                x.Name = "```| Friends   Damage      DPS       Downs     Deaths |```";
                 x.Value = $"{friendlyOverview}";
                 x.IsInline = false;
             });
 
             message.AddField(x =>
             {
-                x.Name = "Enemies";
+                x.Name = "```| Enemies   Damage      DPS       Downs     Deaths |```";
                 x.Value = $"{enemyOverview}";
                 x.IsInline = false;
             });
 
             message.AddField(x =>
             {
-                x.Name = "Damage";
+                x.Name = "```| #            Name              Damage      DPS   |```";
                 x.Value = $"{damageOverview}";
                 x.IsInline = false;
             });
 
             message.AddField(x =>
             {
-                x.Name = "Cleanses";
+                x.Name = "```| #            Name                  Cleanses      |```";
                 x.Value = $"{cleanseOverview}";
                 x.IsInline = false;
             });
 
             message.AddField(x =>
             {
-                x.Name = "Strips";
+                x.Name = "```| #            Name                   Strips       |```";
                 x.Value = $"{stripOverview}";
                 x.IsInline = false;
             });
 
+            /*
             message.AddField(x =>
             {
                 x.Name = "Stability";
                 x.Value = $"{stabOverview}";
                 x.IsInline = false;
             });
+            */
 
             // Joke footers
             var footerMessageVariants = new[]


### PR DESCRIPTION
Adjusted message to be tighter visually (using headers as titles to save space). Adjusted player counts to go to 10, and also changed the indices to be padded. Disabled the stability embed for now.