### PR TITLE
Fixed embed searching

### DIFF
--- a/GW2-DonBot/Controller/Discord/DiscordCore.cs
+++ b/GW2-DonBot/Controller/Discord/DiscordCore.cs
@@ -81,10 +81,7 @@ namespace Controller.Discord
            
             var webhook = new DiscordWebhookClient(secrets.WebhookUrl); 
 
-            var urls = seenMessage.Embeds.SelectMany((x => x.Fields[0].Value.Split('('))).Where(x => x.Contains(")")).ToList();
-            //var urls = seenMessage.Embeds.FirstOrDefault()?.Url != string.Empty && seenMessage.Embeds.FirstOrDefault()?.Url != null
-            //    ? new List<string> { seenMessage.Embeds.FirstOrDefault()?.Url ?? string.Empty }
-            //    : seenMessage.Embeds.SelectMany((x => x.Fields[0].Value.Split('('))).Where(x => x.Contains(")")).ToList();
+            var urls = seenMessage.Embeds.SelectMany((x => x.Fields.SelectMany(y => y.Value.Split('(')))).Where(x => x.Contains(")")).ToList();
 
             var trimmedUrls = urls.Select(url => url.Contains(')') ? url[..url.IndexOf(')')] : url).ToList();
 
@@ -97,6 +94,7 @@ namespace Controller.Discord
 
             foreach (var url in trimmedUrls)
             {
+                Console.WriteLine($"[DON] Assessing: {url}");
                 await AnalyseAndReportOnUrl(webhook, url);
             }
         }


### PR DESCRIPTION
Added another line of debug to help understand what logs have actually been scraped from the message received. Adjusted the embed searching to look through all embeds (sometimes the message puts the urls in several embeds rather than just one). Potentially need to bring back the url checking (the longer line) - or append it to the list, and then just rely on the seen structure to prevent duplicates from being posted twice.