### PR TITLE
Add dps and cleave dps calculation to the logs page

### DIFF
--- a/DonBot.Api/Endpoints/AuthEndpoints.cs
+++ b/DonBot.Api/Endpoints/AuthEndpoints.cs
@@ -12,6 +12,7 @@ public static class AuthEndpoints
 {
     public static void MapAuthEndpoints(this WebApplication app)
     {
+        app.MapGet("/", DefaultApiLanding);
         app.MapGet("/auth/discord", HandleDiscordLogin);
         app.MapGet("/auth/discord/callback", HandleDiscordCallback);
         app.MapPost("/auth/logout", HandleLogout);
@@ -127,5 +128,11 @@ public static class AuthEndpoints
             ?? [];
         var showCookieBanner = bannerIds.Contains(discordId);
         return Results.Ok(new { discordId, username, showCookieBanner });
+    }
+
+    private static IResult DefaultApiLanding(ClaimsPrincipal user, IConfiguration configuration)
+    {
+        var nuxtBaseUrl = configuration["Nuxt:BaseUrl"] ?? "http://localhost:3000";
+        return Results.Redirect($"{nuxtBaseUrl}/dashboard");
     }
 }

--- a/DonBot.Web/app/pages/logs/[id].vue
+++ b/DonBot.Web/app/pages/logs/[id].vue
@@ -181,8 +181,14 @@
                 <Column header="Damage" :sortable="true" sort-field="damage">
                   <template #body="{ data }">{{ data.damage.toLocaleString() }}</template>
                 </Column>
+                <Column header="DPS" :sortable="true" sort-field="damage">
+                  <template #body="{ data }">{{ Number(data.damage / (fight.log.fightDurationInMs / 1000)).toFixed(0) }}</template>
+                </Column>
                 <Column header="Cleave" :sortable="true" sort-field="cleave">
                   <template #body="{ data }">{{ data.cleave.toLocaleString() }}</template>
+                </Column>
+                <Column header="Cleave DPS" :sortable="true" sort-field="cleave">
+                  <template #body="{ data }">{{ Number(data.cleave / (fight.log.fightDurationInMs / 1000)).toFixed(0) }}</template>
                 </Column>
                 <Column header="Alac%" :sortable="true" sort-field="alacDuration">
                   <template #body="{ data }">{{ Number(data.alacDuration).toFixed(2) }}%</template>

--- a/DonBot.Web/app/pages/logs/[id].vue
+++ b/DonBot.Web/app/pages/logs/[id].vue
@@ -150,7 +150,13 @@
             <template #content><div class="stat-label">Total Damage</div><div v-fit-text class="stat-value">{{ sum('damage').toLocaleString() }}</div></template>
           </Card>
           <Card class="stat-card">
+            <template #content><div class="stat-label">Group DPS</div><div v-fit-text class="stat-value">{{ Number((sum('damage') / (fight.log.fightDurationInMs / 1000)).toFixed(0)).toLocaleString() }}</div></template>
+          </Card>
+          <Card class="stat-card">
             <template #content><div class="stat-label">Total Cleave</div><div v-fit-text class="stat-value">{{ sum('cleave').toLocaleString() }}</div></template>
+          </Card>
+          <Card class="stat-card">
+            <template #content><div class="stat-label">Group Cleave</div><div v-fit-text class="stat-value">{{ Number((sum('cleave') / (fight.log.fightDurationInMs / 1000)).toFixed(0)).toLocaleString() }}</div></template>
           </Card>
           <Card class="stat-card">
             <template #content><div class="stat-label">Avg Alac%</div><div v-fit-text class="stat-value">{{ avg('alacDuration').toFixed(1) }}%</div></template>
@@ -182,13 +188,13 @@
                   <template #body="{ data }">{{ data.damage.toLocaleString() }}</template>
                 </Column>
                 <Column header="DPS" :sortable="true" sort-field="damage">
-                  <template #body="{ data }">{{ Number(data.damage / (fight.log.fightDurationInMs / 1000)).toFixed(0) }}</template>
+                  <template #body="{ data }">{{ Number((data.damage / (fight.log.fightDurationInMs / 1000)).toFixed(0)).toLocaleString() }}</template>
                 </Column>
                 <Column header="Cleave" :sortable="true" sort-field="cleave">
                   <template #body="{ data }">{{ data.cleave.toLocaleString() }}</template>
                 </Column>
                 <Column header="Cleave DPS" :sortable="true" sort-field="cleave">
-                  <template #body="{ data }">{{ Number(data.cleave / (fight.log.fightDurationInMs / 1000)).toFixed(0) }}</template>
+                  <template #body="{ data }">{{ Number((data.cleave / (fight.log.fightDurationInMs / 1000)).toFixed(0)).toLocaleString() }}</template>
                 </Column>
                 <Column header="Alac%" :sortable="true" sort-field="alacDuration">
                   <template #body="{ data }">{{ Number(data.alacDuration).toFixed(2) }}%</template>


### PR DESCRIPTION
I just did the change in the frontend, but we might want to just do the calculation on the server/store it on the server if we want to use it in a lot of places

<img width="1729" height="867" alt="image" src="https://github.com/user-attachments/assets/c03b2357-11c7-4be3-9457-733d06579b12" />
